### PR TITLE
New sensor fo Azimut now supported.

### DIFF
--- a/custom_components/sws12500/const.py
+++ b/custom_components/sws12500/const.py
@@ -1,5 +1,6 @@
 """Constants."""
 
+from enum import StrEnum
 from typing import Final
 
 DOMAIN = "sws12500"
@@ -59,6 +60,7 @@ OUTSIDE_HUMIDITY: Final = "outside_humidity"
 WIND_SPEED: Final = "wind_speed"
 WIND_GUST: Final = "wind_gust"
 WIND_DIR: Final = "wind_dir"
+WIND_AZIMUT: Final = "wind_azimut"
 RAIN: Final = "rain"
 DAILY_RAIN: Final = "daily_rain"
 SOLAR_RADIATION: Final = "solar_radiation"
@@ -89,3 +91,41 @@ REMAP_ITEMS: dict = {
 
 DISABLED_BY_DEFAULT: Final = [CH2_TEMP, CH2_HUMIDITY]
 
+class UnitOfDir(StrEnum):
+    """Wind direrction azimut."""
+
+    NNE = "NNE"
+    NE = "NE"
+    ENE = "ENE"
+    E = "E"
+    ESE = "ESE"
+    SE = "SE"
+    SSE = "SSE"
+    S = "S"
+    SSW = "SSW"
+    SW = "SW"
+    WSW = "WSW"
+    W = "W"
+    WNW = "WNW"
+    NW = "NW"
+    NNW = "NNW"
+    N = "N"
+
+AZIMUT: list[UnitOfDir] = [
+    UnitOfDir.NNE,
+    UnitOfDir.NE,
+    UnitOfDir.ENE,
+    UnitOfDir.E,
+    UnitOfDir.ESE,
+    UnitOfDir.SE,
+    UnitOfDir.SSE,
+    UnitOfDir.S,
+    UnitOfDir.SSW,
+    UnitOfDir.SW,
+    UnitOfDir.WSW,
+    UnitOfDir.W,
+    UnitOfDir.WNW,
+    UnitOfDir.NW,
+    UnitOfDir.NNW,
+    UnitOfDir.N,
+]

--- a/custom_components/sws12500/strings.json
+++ b/custom_components/sws12500/strings.json
@@ -76,7 +76,28 @@
       "daily_rain": { "name": "Daily precipitation" },
       "solar_radiation": { "name": "Solar irradiance" },
       "ch2_temp": { "name": "Channel 2 temperature" },
-      "ch2_humidity": { "name": "Channel 2 humidity" }
+      "ch2_humidity": { "name": "Channel 2 humidity" },
+      "wind_azimut": {
+        "name": "Bearing",
+        "state": {
+          "N": "N",
+          "NNE": "NNE",
+          "NE": "NE",
+          "ENE": "ENE",
+          "E": "E",
+          "ESE": "ESE",
+          "SE": "SE",
+          "SSE": "SSE",
+          "S": "S",
+          "SSW": "SSW",
+          "SW": "SW",
+          "WSW": "WSW",
+          "W": "W",
+          "WNW": "WNW",
+          "NW": "NW",
+          "NNW": "NNW"
+        }
+      }
     }
   },
   "notify": {

--- a/custom_components/sws12500/translations/cs.json
+++ b/custom_components/sws12500/translations/cs.json
@@ -75,7 +75,28 @@
       "daily_rain": { "name": "Denní úhrn srážek" },
       "solar_radiation": { "name": "Sluneční osvit" },
       "ch2_temp": { "name": "Teplota senzoru 2" },
-      "ch2_humidity": { "name": "Vlhkost sensoru 2" }
+      "ch2_humidity": { "name": "Vlhkost sensoru 2" },
+      "wind_azimut": {
+            "name": "Azimut",
+            "state": {
+              "N": "S",
+              "NNE": "SSV",
+              "NE": "SV",
+              "ENE": "VVS",
+              "E": "V",
+              "ESE": "VVJ",
+              "SE": "JV",
+              "SSE": "JJV",
+              "S": "J",
+              "SSW": "JJZ",
+              "SW": "JZ",
+              "WSW": "JZZ",
+              "W": "Z",
+              "WNW": "ZZS",
+              "NW": "SZ",
+              "NNW": "SSZ"
+            }
+          }
     }
   },
   "notify": {

--- a/custom_components/sws12500/translations/en.json
+++ b/custom_components/sws12500/translations/en.json
@@ -76,7 +76,28 @@
       "daily_rain": { "name": "Daily precipitation" },
       "solar_radiation": { "name": "Solar irradiance" },
       "ch2_temp": { "name": "Channel 2 temperature" },
-      "ch2_humidity": { "name": "Channel 2 humidity" }
+      "ch2_humidity": { "name": "Channel 2 humidity" },
+      "wind_azimut": {
+        "name": "Bearing",
+        "state": {
+          "N": "N",
+          "NNE": "NNE",
+          "NE": "NE",
+          "ENE": "ENE",
+          "E": "E",
+          "ESE": "ESE",
+          "SE": "SE",
+          "SSE": "SSE",
+          "S": "S",
+          "SSW": "SSW",
+          "SW": "SW",
+          "WSW": "WSW",
+          "W": "W",
+          "WNW": "WNW",
+          "NW": "NW",
+          "NNW": "NNW"
+        }
+      }
     }
   },
   "notify": {

--- a/custom_components/sws12500/utils.py
+++ b/custom_components/sws12500/utils.py
@@ -7,7 +7,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.translation import async_get_translations
 
-from .const import DEV_DBG, REMAP_ITEMS, SENSORS_TO_LOAD
+from .const import AZIMUT, DEV_DBG, REMAP_ITEMS, SENSORS_TO_LOAD, UnitOfDir
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -128,3 +128,16 @@ def check_disabled(
                 _LOGGER.info("Add sensor (%s) to loading queue", item)
 
     return missing_sensors if entityFound else None
+
+def wind_dir_to_text(deg: float) -> UnitOfDir | None:
+    """Return wind direction in text representation.
+
+    Returns UnitOfDir or None
+    """
+
+    if deg:
+        return AZIMUT[int(abs((float(deg) - 11.25) % 360) / 22.5)]
+
+    return None
+
+


### PR DESCRIPTION
- A new constant `WIND_AZIMUT` is added to allow creating a wind direction sensor that returns a text value from `UnitOfDir` instead of just a numeric degree value.

- The wind direction sensor entity now optionally creates both a numeric wind direction sensor using `WIND_DIR` and a text-based azimuth sensor using `WIND_AZIMUT`. If the numeric one is enabled, the text one will also be added.

So in summary, these changes improve the usability of wind data by adding a more human-readable text version alongside the existing numeric version.
