### PR TITLE
Corrects wind direction sensor state class

### DIFF
--- a/custom_components/sws12500/sensors_weather.py
+++ b/custom_components/sws12500/sensors_weather.py
@@ -122,7 +122,8 @@ SENSOR_TYPES_WEATHER_API: tuple[WeatherSensorEntityDescription, ...] = (
     WeatherSensorEntityDescription(
         key=WIND_DIR,
         native_unit_of_measurement=DEGREE,
-        state_class=SensorStateClass.MEASUREMENT,
+        state_class=SensorStateClass.MEASUREMENT_ANGLE,
+        device_class=SensorDeviceClass.WIND_DIRECTION,
         suggested_display_precision=None,
         icon="mdi:sign-direction",
         translation_key=WIND_DIR,

--- a/custom_components/sws12500/sensors_wslink.py
+++ b/custom_components/sws12500/sensors_wslink.py
@@ -132,7 +132,7 @@ SENSOR_TYPES_WSLINK: tuple[WeatherSensorEntityDescription, ...] = (
     WeatherSensorEntityDescription(
         key=WIND_DIR,
         native_unit_of_measurement=DEGREE,
-        state_class=None,
+        state_class=SensorStateClass.MEASUREMENT_ANGLE,
         device_class=SensorDeviceClass.WIND_DIRECTION,
         suggested_display_precision=None,
         icon="mdi:sign-direction",


### PR DESCRIPTION
Updates the wind direction sensor to use `MEASUREMENT_ANGLE` state class for proper representation in Home Assistant.

This ensures correct interpretation of wind direction as an angle.
